### PR TITLE
Replacing method of detecting external cell

### DIFF
--- a/espParser/scripts/espParser.lua
+++ b/espParser/scripts/espParser.lua
@@ -267,10 +267,9 @@ espParser.parseCells = function(filename) --filename already loaded in espParser
 			end
 		end
 
-		if cell.name == "" then --its a external cell
+		if cell.region ~= nil or cell.name == "" then --its a external cell
 			cell.isExterior = true
 			cell.name = cell.gridX .. ", " .. cell.gridY
-
 		else --its a internal cell
 			cell.isExterior = false
 		end


### PR DESCRIPTION
Original method only accounts for cell name being empty. However, some external cells have names (such as "Ald-ruhn") for mapping purposes. This adds a region check (internal cells do not have regions afaik).